### PR TITLE
Sort float fix and img fix

### DIFF
--- a/hashover/style-sheets/modern.css
+++ b/hashover/style-sheets/modern.css
@@ -208,7 +208,6 @@ Copyright (C) 2014 Jacob Barkdull
 
 .hashover-sort {
 	float: right;
-	display: block;
 }
 
 .hashover-sort select {
@@ -314,8 +313,9 @@ Copyright (C) 2014 Jacob Barkdull
 		display: block;
 	}
 
-	.hashover-avatar {
+	.hashover-avatar img{
 		width: 20px;
+		height:20px;
 	}
 
 	.hashover-comment {
@@ -332,6 +332,7 @@ Copyright (C) 2014 Jacob Barkdull
 
 	.hashover-sort{
 		float: none;
+		display: inline-block;
 	}
 }
 


### PR DESCRIPTION
Chrome has a weird bug with display:block and float:right on the sort when resizing.

Also, changed the avatar size rule cause it breaks the small size layout on firefox (temporary, until I replace this with an icon instead of png)
