### PR TITLE
No avatar image should be just that

### DIFF
--- a/hashover/scripts/javascript-mode.php
+++ b/hashover/scripts/javascript-mode.php
@@ -113,9 +113,10 @@ function hashover_reply(r, f) {
 <?php
 
 	if (!empty($_COOKIE['hashover-login'])) {
-
+	if ($this->setup->uses_icons == 'yes') {
 ?>
 	reply_form += '<div class="hashover-avatar-image"><img width="<?php echo $this->setup->icon_size; ?>" height="<?php echo $this->setup->icon_size; ?>" src="/hashover/images/<?php echo $this->setup->image_format; ?>s/first-comment.<?php echo $this->setup->image_format; ?>" alt="#' + f + '"></div>';
+	<?php } ?>
 	reply_form += '<input type="hidden" name="name" value="<?php if (!empty($_COOKIE['name'])) echo $_COOKIE['name']; ?>">\n';
 	reply_form += '<input type="hidden" name="password" value="<?php if (!empty($_COOKIE['password'])) echo $_COOKIE['password']; ?>">\n';
 	reply_form += '<input type="hidden" name="email" value="<?php if (!empty($_COOKIE['email'])) echo $_COOKIE['email']; ?>">\n';
@@ -126,8 +127,9 @@ function hashover_reply(r, f) {
 
 ?>
 	reply_form += '<div class="hashover-inputs">\n';
+	<?php if ($this->setup->uses_icons == 'yes') { ?>
 	reply_form += '<div class="hashover-avatar-image"><img width="<?php echo $this->setup->icon_size; ?>" height="<?php echo $this->setup->icon_size; ?>" src="/hashover/images/<?php echo $this->setup->image_format; ?>s/first-comment.<?php echo $this->setup->image_format; ?>" alt="#' + f + '"></div>';
-
+	<?php } ?>
 	if (name_on) {
 		reply_form += '<div class="hashover-name-input">\n<input type="text" name="name" title="<?php echo $this->setup->text['name_tip']; ?>" value="<?php if (!empty($_COOKIE['name'])) echo $_COOKIE['name']; ?>" maxlength="30" placeholder="<?php echo $this->setup->text['name']; ?>">\n</div>\n';
 	}

--- a/hashover/scripts/javascript-mode.php
+++ b/hashover/scripts/javascript-mode.php
@@ -731,9 +731,7 @@ hashover += '\t\t<div class="hashover-inputs">\n';
 
 	if ($this->setup->uses_icons == 'yes') {
 		echo $this->setup->escape_output('\t\t\t<div class="hashover-avatar-image">' . $form_avatar . '</div>');
-	} else {
-		echo $this->setup->escape_output('\t\t\t<div class="hashover-avatar-image"><span>#' . $this->read_comments->cmt_count . '</span></div>');
-	}
+	} 
 
 	if (!empty($_COOKIE['hashover-login'])) {
 		echo 'hashover += \'\t\t\t<div>\n\';', PHP_EOL;


### PR DESCRIPTION
I honestly don't understand the number that's shown instead of an avatar image if it's disabled in the settings. The code suggests it's a post count but in my testing it seemed wrong?

Regardless, the setting of disabling avatars should do just that and not add something else.

Perhaps add another possible setting to replace the avatar with some post count or something else... and then just an else if in the code above.

PS. Please excuse the sloppy code I added for the reply forms.