### PR TITLE
Remove duplicate class

### DIFF
--- a/hashover/scripts/javascript-mode.php
+++ b/hashover/scripts/javascript-mode.php
@@ -738,7 +738,7 @@ function show_cmts(element) {
 <?php } ?>
 <?php
 
-	echo $this->setup->escape_output('<span class="hashover-title hashover-main-title hashover-dashed-title">' . $js_title . '</span>\n');
+	echo $this->setup->escape_output('<span class="hashover-title hashover-main-title">' . $js_title . '</span>\n');
 
 	if (!empty($_COOKIE['message'])) {
 		echo $this->setup->escape_output('<span id="hashover-message" class="hashover-title">' . $_COOKIE['message'] . '</span>\n');


### PR DESCRIPTION
dashed-title is unnecessary here and conflicts with styling of the comment count/sort.

Perhaps that needs a more clear class name as well, like hashover-sort-count... but smarter than that lol.

Don't know if dashed-title is used elsewhere too