### PR TITLE
Add class for first default avatar div

### DIFF
--- a/hashover/scripts/javascript-mode.php
+++ b/hashover/scripts/javascript-mode.php
@@ -141,7 +141,7 @@ function hashover_reply(r, f) {
 	var reply_form = '<div class="hashover-balloon">';
 <?php
 
-	$first_cmt_image = '<div class="hashover-avatar-image">' . $form_first_image . '</div>';
+	$first_cmt_image = '<div class="hashover-avatar-image hashover-avatar-image">' . $form_first_image . '</div>';
 
 	if (!empty($_COOKIE['hashover-login'])) {
 		$first_cmt_image = '<div class="hashover-avatar-image">' . $form_avatar . '</div>';

--- a/hashover/scripts/javascript-mode.php
+++ b/hashover/scripts/javascript-mode.php
@@ -781,7 +781,7 @@ hashover += '\t\t<div class="hashover-inputs">\n';
 			if (!empty($_COOKIE['hashover-login'])) {
 				echo $this->setup->escape_output('\t\t\t<div class="hashover-avatar-image">' . $form_avatar . '</div>');
 			} else {
-				echo $this->setup->escape_output('\t\t\t<div class="hashover-avatar-image">' . $form_first_image . '</div>');
+				echo $this->setup->escape_output('\t\t\t<div class="hashover-avatar-image hashover-avatar-first">' . $form_first_image . '</div>');
 			}
 		} else {
 			echo $this->setup->escape_output('\t\t\t<div class="hashover-avatar-image"><span>#' . $this->read_comments->cmt_count . '</span></div>');


### PR DESCRIPTION
Until there's a better (?) solution the default, first post/new user avatar should have a distinct class. Reasons:

So one can hide it completely. Example:

- I want avatars (including the default for anonymous users)
- I don't want the default first post image next to the input fields before the user makes a first post/logs in - only show the input fields

Unless there's another if statement added, using css is the only way to hide it (though dirty and not to my liking)