### PR TITLE
Remove the mobile block?

### DIFF
--- a/hashover/scripts/javascript-mode.php
+++ b/hashover/scripts/javascript-mode.php
@@ -821,18 +821,6 @@ if (password_on) {
 	hashover += '\t\t\t</div>\n';
 }
 
-<?php
-
-	if ($this->setup->is_mobile) {
-		echo 'hashover += \'\t\t\t</div>\n\t\t\t<div class="hashover-inputs">\n\';', PHP_EOL;
-
-		if ($this->setup->icon_mode != 'none') {
-			echo 'hashover += \'\t\t\t\t<div class="hashover-avatar-image"></div>\n\';', PHP_EOL;
-		}
-	}
-
-?>
-
 // Display email input tag if told to
 if (email_on) {
 	hashover += '\t\t\t<div class="hashover-email-input">\n';


### PR DESCRIPTION
Why is this needed? 

As I can see it splits hashover-inputs in two divs. If it's about different positioning on mobile, that should be handled through css.

With the growth of high resolution mobile devices, using this kind of detection isn't really reliable from a design stand point.