### PR TITLE
Make HashOver able to work in a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ Information and Documentation
 ---
 http://tildehash.com/?page=hashover
 
+** IMPORTANT NOTICE **
+
+This version modifies the file organisation to handle all in one subdirectory `hashover-next` of the root of the website.
+All the documentation of the previous version is still valid, but you must correct all the path when you read it, prefixing them with `/hashover-next/`.
+
+For example, to use Hashover-Next with the JavaScript method, you shoud use this code :
+
+	<script type="text/javascript" src="/hashover-next/hashover.js"></script>
+	<noscript>You must have JavaScript enabled to use the comments.</noscript>
+
 Focus of this release
 ---
 HashOver [version 1.0](https://github.com/jacobwb/hashover) consists of code written by [one person](http://tildehash.com/?page=author) over the course of five years, come March the 29th 2014. Moreover, HashOver was my first serious use of JavaScript and my first PHP project of such complexity. Those two facts should trigger obvious concerns about HashOver's performance, efficiency, and security. With that in mind, version 2.0 will be the next release, skipping 1.x releases all together, and will focus on improving nothing but the following areas.
@@ -63,7 +73,7 @@ HashOver [version 1.0](https://github.com/jacobwb/hashover) consists of code wri
 - Graphic scalability on (*x<sup>i</sup>*)HDPI displays [[#4](https://github.com/jacobwb/hashover-next/issues/4)] [[#11](https://github.com/jacobwb/hashover-next/issues/11)]
 - Code readability [[#62](https://github.com/jacobwb/hashover-next/issues/62)] [[#63](https://github.com/jacobwb/hashover-next/issues/63)]
 - Bug fixes
-		
+
 This means the possibility of new features in version 2.0 is next to null, and contributions via GitHub and/or e-mail that add new features will be rejected, at least for the time being. Improvements to existing functionality and aesthetics will be accepted. New features will be accepted and available in version 2.x releases.
 
 Contributing

--- a/hashover.js
+++ b/hashover.js
@@ -18,9 +18,9 @@
 //
 // Get Complete Source Code:
 //
-// The source code for each PHP script used in HashOver is normally 
-// accessible directly from each script. You can simply visit the script 
-// file with the "source" query and the script will generate and display 
+// The source code for each PHP script used in HashOver is normally
+// accessible directly from each script. You can simply visit the script
+// file with the "source" query and the script will generate and display
 // its own source code.
 //
 // Like so:
@@ -111,7 +111,7 @@
 	// Append HashOver JavaScript tag to the page body
 	var script = document.createElement ('script');
 	    script.type = 'text/javascript';
-	    script.src  = '/hashover' + scriptSrc;
+	    script.src  = '/hashover-next/hashover' + scriptSrc;
 	    script.src += '?' + scriptQueries;
 	    script.src += '&' + 'hashover-script=' + scriptNumber;
 	    script.id = 'hashover-script-' + scriptNumber;

--- a/hashover.js
+++ b/hashover.js
@@ -109,9 +109,19 @@
 	}
 
 	// Append HashOver JavaScript tag to the page body
+	var fileName = "hashover.js";
+	var scriptList = document.getElementsByTagName('script');
+	for (var i = 0; i < scriptList.length; i++) {
+		var mejs = scriptList[i].src
+		console.log(mejs.substring(mejs.lastIndexOf("/") + 1));
+		if (mejs.substring(mejs.lastIndexOf("/") + 1) === fileName){
+			basePath = mejs.substring(0, mejs.lastIndexOf("/") + 1);
+		}
+	}
+
 	var script = document.createElement ('script');
 	    script.type = 'text/javascript';
-	    script.src  = '/hashover-next/hashover' + scriptSrc;
+	    script.src  = basePath+'hashover' + scriptSrc;
 	    script.src += '?' + scriptQueries;
 	    script.src += '&' + 'hashover-script=' + scriptNumber;
 	    script.id = 'hashover-script-' + scriptNumber;

--- a/hashover/changelog.txt
+++ b/hashover/changelog.txt
@@ -1,3 +1,7 @@
+Changes by Stéphane Mourey 2016-01-19
+--------------------------------------------------------------------------------
+* Enabling Hashover to work in the hashover-next subdirectory, not breaking change
+
 Changes by Jacob Barkdull 2016-01-09
 --------------------------------------------------------------------------------
 * Fixed: Administrative comment deletion requiring name and password.
@@ -148,7 +152,7 @@ Changes by Jacob Barkdull 2015-12-12
 * hashover/scripts/settings.php,
   hashover/scripts/hashover.php
 
-	- Logic for comment reply nesting modified to allow a configurable 
+	- Logic for comment reply nesting modified to allow a configurable
 	  number of indentation levels, after which the thread is flattened.
 
 	- Added public $usesAJAX setting.
@@ -197,7 +201,7 @@ Changes by Jacob Barkdull 2015-12-12
 * Improved error handling
 
 	- Classes now throw Exceptions, and try/catch blocks are used to display
-	  the error messages, `escapeOutput ()` has been removed and the new 
+	  the error messages, `escapeOutput ()` has been removed and the new
 	  `displayErrors ()` in the new Misc class is used as a wrapper instead.
 
 
@@ -937,7 +941,7 @@ Changes by Jacob Barkdull 2015-03-21
 	  'none' `$icon_mode` option. Wrap avatar in span tag.
 
 	- Added workaround for Chrome bug.
-	
+
 		Anchor "jump" tags aren't followed if the linked element isn't
 		on the page before the page begins loading.
 

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -3,25 +3,25 @@
 // Copyright (C) 2010-2015 Jacob Barkdull
 // This file is part of HashOver.
 //
-// I, Jacob Barkdull, hereby release this work into the public domain. 
-// This applies worldwide. If this is not legally possible, I grant any 
-// entity the right to use this work for any purpose, without any 
+// I, Jacob Barkdull, hereby release this work into the public domain.
+// This applies worldwide. If this is not legally possible, I grant any
+// entity the right to use this work for any purpose, without any
 // conditions, unless such conditions are required by law.
 //
 //--------------------
 //
 // IMPORTANT NOTICE:
 //
-// To retain your settings and maintain proper functionality, when 
-// downloading or otherwise upgrading to a new version of HashOver it 
+// To retain your settings and maintain proper functionality, when
+// downloading or otherwise upgrading to a new version of HashOver it
 // is important that you preserve this file, unless directed otherwise.
 //
-// It is also important to choose UNIQUE values for the encryption key, 
-// admin name, and admin password, as not doing so puts HashOver at 
-// risk of being hijacked. Allowing someone to delete comments and/or 
-// edit existing comments to post spam, impersonate you or your 
-// visitors in order to push some sort of agenda/propaganda, to defame 
-// you or your visitors, or to imply endorsement of some product(s), 
+// It is also important to choose UNIQUE values for the encryption key,
+// admin name, and admin password, as not doing so puts HashOver at
+// risk of being hijacked. Allowing someone to delete comments and/or
+// edit existing comments to post spam, impersonate you or your
+// visitors in order to push some sort of agenda/propaganda, to defame
+// you or your visitors, or to imply endorsement of some product(s),
 // service(s), and/or political ideology.
 //
 //
@@ -147,7 +147,7 @@ class Settings
 
 		// Technical settings
 		$this->rootDirectory	= $dirname;			// Root directory for script
-		$this->httpRoot		= '/' . basename ($dirname);	// Root directory for HTTP
+		$this->httpRoot		= dirname(dirname($_SERVER['PHP_SELF']));	// Root directory for HTTP
 		$this->cookieExpiration	= time () + 60 * 60 * 24 * 30;	// Cookie expiration date
 		$this->domain		= $_SERVER['HTTP_HOST'];	// Domain name for refer checking & notifications
 


### PR DESCRIPTION
This change enable HashOver-next to work in a subdirectory as `/hashover-next` which is the directory created by Git when cloning the web root directory.
It fixes issue https://github.com/jacobwb/hashover-next/issues/124
Note this does not *break backward compatibility*. You can still use HashOver-next in top directory.