### PR TITLE
Replace backslashes with forwardslashes

### DIFF
--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -137,8 +137,8 @@ class Settings
 		$document_root = realpath ($_SERVER['DOCUMENT_ROOT']);
 		$http_directory = mb_substr ($root_directory, mb_strlen ($document_root));
 		
-		//Replace backslashes with forwardslashes
-		$http_directory = str_replace('\\', '/', $http_directory);
+		// Replace backslashes with forwardslashes
+		$http_directory = str_replace ('\\', '/', $http_directory);
 		
 		// Technical settings
 		$this->rootDirectory	= $root_directory;		// Root directory for script

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -136,7 +136,10 @@ class Settings
 		// Get HTTP parent directory
 		$document_root = realpath ($_SERVER['DOCUMENT_ROOT']);
 		$http_directory = mb_substr ($root_directory, mb_strlen ($document_root));
-
+		
+		//Replace backslashes with forwardslashes
+		$http_directory = str_replace('\\', '/', $http_directory);
+		
 		// Technical settings
 		$this->rootDirectory	= $root_directory;		// Root directory for script
 		$this->httpRoot		= $http_directory;		// Root directory for HTTP


### PR DESCRIPTION
In Windows Operating System the realpath function will return string with backslash as directory separator, it will result a problem in javascript.