### PR TITLE
(Readme.md) Remove redundant type attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Important differences from version 1.0
   To:
 
   ```html
-  <script type="text/javascript" src="/hashover/hashover.js"></script>
+  <script src="/hashover/hashover.js"></script>
   ```
 
 - HashOver 2.0 is object oriented, many things have changed places and been renamed. For normal users, about the only thing that is important to know is that the `secrets.php` file was merged with the `settings.php` file.


### PR DESCRIPTION
>The type attribute allows customization of the type of script represented:
>
> * Omitting the attribute, or setting it to a JavaScript MIME type, means that the script is a classic script, to be interpreted according to the JavaScript Script top-level production. Classic scripts are affected by the charset, async, and defer attributes. **Authors should omit the attribute, instead of redundantly giving a JavaScript MIME type**.

This recommendation is taken from W3C HTML 5.1 Recommendation: https://www.w3.org/TR/html51/semantics-scripting.html#the-script-element. The highlighting was made by me.