### PR TITLE
Mark hashover.js as free software readable by LibreJS

### DIFF
--- a/hashover/hashover.js
+++ b/hashover/hashover.js
@@ -1,3 +1,6 @@
+// @licstart  The following is the entire license notice for the
+// JavaScript code in this page.
+//
 // Copyright (C) 2010-2017 Jacob Barkdull
 // This file is part of HashOver.
 //
@@ -14,6 +17,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with HashOver.  If not, see <http://www.gnu.org/licenses/>.
 //
+// @licend  The above is the entire license notice
+// for the JavaScript code in this page.
 //--------------------
 //
 // Get Complete Source Code:


### PR DESCRIPTION
However, after marking the script as free software. I got another script blocked error in my website related to a file called `hashover-javascript.php`, so issue #169 is still not solved. I don't know yet what is the problem there, that seems a PHP.

> NONTRIVIAL: square bracket suffix method call detected
https://www.freakspot.net/hashover-next/scripts/hashover-javascript.php?url=https%3A%2F%2Fwww.freakspot.net%2Fprompt-para-git-en-bash%2F&title=Prompt%20para%20Git%20en%20Bash&hashover-script=3

EDIT: I followed this guide: https://www.gnu.org/software/librejs/free-your-javascript.html