### PR TITLE
Fixed auto load of hashover/pdo.php file

### DIFF
--- a/hashover/scripts/parsesql.php
+++ b/hashover/scripts/parsesql.php
@@ -73,7 +73,7 @@ class ParseSQL extends Database
 
 		if ($results !== false) {
 			$results->execute ();
-			$fetchAll = $results->fetchAll (PDO::FETCH_NUM);
+			$fetchAll = $results->fetchAll (\PDO::FETCH_NUM);
 			$return_array = array ();
 
 			for ($i = 0, $il = count ($fetchAll); $i < $il; $i++) {
@@ -108,7 +108,7 @@ class ParseSQL extends Database
 		);
 
 		if ($result !== false) {
-			return (array) $result->fetch (PDO::FETCH_ASSOC);
+			return (array) $result->fetch (\PDO::FETCH_ASSOC);
 		}
 
 		return false;


### PR DESCRIPTION
I've implemented hashover with mysql database. When the library reads a comment it fires this error: "HashOver PDO.php file could not be included!" it happen because it try to load the file PDO.php that not exists. I've fixed the error by putting the slash in the "PDO::" calls