### PR TITLE
Added support for multi languages site Fixed email sender bug. Added customization of webmaster notification subject. Added the possibility to order in ASC and DESC

### DIFF
--- a/hashover/scripts/javascript-mode.php
+++ b/hashover/scripts/javascript-mode.php
@@ -62,6 +62,7 @@ if ($hashover->setup->collapsesComments !== false) {
 }
 
 // Some short variables (FIXME: this is cosmetic)
+$allowsReplies = $hashover->setup->allowsReplies;
 $allowsLikes = !!$hashover->setup->allowsLikes;
 $allowsDislikes = !!$hashover->setup->allowsDislikes;
 $likesOrDislikes = ($allowsLikes or $allowsDislikes);
@@ -189,6 +190,7 @@ HashOver.init = function ()
 	var collapsedCount	= 0;
 	var collapseLimit	= <?php echo $hashover->misc->jsEscape ($hashover->setup->collapseLimit); ?>;
 	var defaultName		= '<?php echo $hashover->misc->jsEscape ($hashover->setup->defaultName); ?>';
+	var allowsReplies	= <?php echo string_true ($allowsReplies); ?>;
 	var allowsDislikes	= <?php echo string_true ($allowsDislikes); ?>;
 	var allowsLikes		= <?php echo string_true ($allowsLikes); ?>;
 	var timeFormat		= <?php echo js_json ($hashover->setup->timeFormat, false); ?>;
@@ -834,8 +836,10 @@ HashOver.init = function ()
 			// Add date from comment as permalink hyperlink to template
 			template.date = '<?php echo $hashover->html->dateLink ('permalink', 'commentDate'); ?>';
 
+<?php if ($allowsReplies !== false): ?>
 			// Add "Reply" hyperlink to template
 			template['reply-link'] = '<?php echo $hashover->html->formLink ('reply', 'permalink', 'replyClass', 'replyTitle'); ?>';
+<?php endif; ?>
 
 			// Add reply count to template
 			if (comment.replies !== undefined) {

--- a/hashover/scripts/locale.php
+++ b/hashover/scripts/locale.php
@@ -59,6 +59,10 @@ class Locale
 
 		// Check if we are automatically selecting the locale
 		if ($language === 'auto') {
+			
+			// get the languages from GET, POST or COOKIES
+			foreach($this->setup->languageVARNames as $VARname) if(isset($_REQUEST[$VARname])) $locales[] = $_REQUEST[$VARname];
+			
 			// If so, get system locale
 			$system_locale = mb_strtolower (setlocale (LC_CTYPE, 0));
 
@@ -77,9 +81,6 @@ class Locale
 			if (!empty ($language_parts[1])) {
 				$locales[] = $language_parts[1];
 			}
-		}else
-		if($language === 'manual'){
-			$locales[] = $_GET['lang'];
 		} else {
 			// If not, add configured locale to checklist
 			$locales[] = $language;

--- a/hashover/scripts/locale.php
+++ b/hashover/scripts/locale.php
@@ -59,10 +59,10 @@ class Locale
 
 		// Check if we are automatically selecting the locale
 		if ($language === 'auto') {
-			
+
 			// get the languages from GET, POST or COOKIES
 			foreach($this->setup->languageVARNames as $VARname) if(isset($_REQUEST[$VARname])) $locales[] = $_REQUEST[$VARname];
-			
+
 			// If so, get system locale
 			$system_locale = mb_strtolower (setlocale (LC_CTYPE, 0));
 

--- a/hashover/scripts/locale.php
+++ b/hashover/scripts/locale.php
@@ -77,6 +77,9 @@ class Locale
 			if (!empty ($language_parts[1])) {
 				$locales[] = $language_parts[1];
 			}
+		}else
+		if($language === 'manual'){
+			$locales[] = $_GET['lang'];
 		} else {
 			// If not, add configured locale to checklist
 			$locales[] = $language;

--- a/hashover/scripts/readcomments.php
+++ b/hashover/scripts/readcomments.php
@@ -41,7 +41,6 @@ class ReadComments
 
 	public function __construct (Setup $setup)
 	{
-		
 		$this->setup = $setup;
 
 		// Instantiate necessary class data format class

--- a/hashover/scripts/readcomments.php
+++ b/hashover/scripts/readcomments.php
@@ -41,6 +41,7 @@ class ReadComments
 
 	public function __construct (Setup $setup)
 	{
+		
 		$this->setup = $setup;
 
 		// Instantiate necessary class data format class
@@ -179,7 +180,11 @@ class ReadComments
 		}
 
 		// Sort comments by their keys alphabetically in ascending order
-		uksort ($this->commentList, 'strnatcasecmp');
+		if($this->setup->readCommentsDESC){
+			uksort($this->commentList, create_function('$a,$b', 'return -strnatcasecmp($a,$b);')); // DESC
+		}else{
+			uksort($this->commentList, 'strnatcasecmp'); // ASC
+		}
 	}
 
 	// Read comments

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -54,12 +54,14 @@ class Settings
 	public $popularityThreshold	= 5;				// Minimum likes a comment needs to be popular
 	public $popularityLimit		= 2;				// Number of comments allowed to become popular
 
-	// Notification email
+	// Webmaster notification email
 	public $notEmail_subject_txt		= 'New comment';	// The initial part of E-Mail notification subject
 	public $notEmail_subject_appEmail	= false;		// Whether append the sender email to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
 	public $notEmail_subject_appName	= false;		// Whether append the name to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
 	public $notEmail_subject_appPage	= false;		// Whether append the page to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
 	
+	// Emails
+	public $emailSender			= NULL;			// Sender email, leave null to select it automatically		
 	
 	// Date and Time settings
 	public $serverTimezone		= 'America/Los_Angeles';	// Server timezone

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -53,6 +53,7 @@ class Settings
 	public $streamDepth		= 3;				// In stream mode, the number of reply indentions to allow before the thread flattens
 	public $popularityThreshold	= 5;				// Minimum likes a comment needs to be popular
 	public $popularityLimit		= 2;				// Number of comments allowed to become popular
+	public $readCommentsDESC	= true;				// Whether it must read the comment in DESC order
 
 	// Webmaster notification email
 	public $notEmail_subject_txt		= 'New comment';	// The initial part of E-Mail notification subject

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -43,6 +43,7 @@ class Settings
 	public $defaultName		= 'Anonymous';			// Default name to use when one isn't given
 	public $allowsImages		= true;				// Whether external image URLs wrapped in [img] tags are embedded
 	public $allowsLogin		= true;				// Whether users can login and logout (when false form cookies are still set)
+	public $allowsReplies 		= true;				// Whether a "Reply" button is displayed
 	public $allowsLikes		= true;				// Whether a "Like" link is displayed
 	public $allowsDislikes		= false;			// Whether a "Dislike" link is displayed; allowing Reddit-style voting
 	public $usesAJAX		= true;				// Whether AJAX is used for posting, editing, and loading comments

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -34,7 +34,9 @@ class Settings
 	protected $adminPassword	= 'passwd';			// Login password to gain admin rights (case-sensitive)
 
 	// Primary settings
-	public $language		= 'auto';			// UI language, for example 'en', 'de', etc. 'auto' to use system locale, 'manual' to pass required locale to "lang" URL parameter
+	public $language		= 'auto';			// UI language, for example 'en', 'de', etc. 'auto' to use system locale
+	public $languageVARNames	= [];				// The list of parameters to check for to get language required, [order is important],if not used leave the array void.
+									// 	E.G ['Lang', 'MyLang'] it'll get the language required from the $_GET, $_POST, $_COOKIE variable that has the names: "Lang" or "MyLang"
 	public $theme			= 'default';			// Comment Cascading Style Sheet (CSS)
 	public $usesModeration		= false;			// Whether comments must be approved before they appear to other visitors
 	public $dataFormat		= 'xml';			// Format comments will be stored in; options: xml, json, sql

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -60,10 +60,10 @@ class Settings
 	public $notEmail_subject_appEmail	= false;		// Whether append the sender email to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
 	public $notEmail_subject_appName	= false;		// Whether append the name to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
 	public $notEmail_subject_appPage	= false;		// Whether append the page to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
-	
+
 	// Emails
 	public $emailSender			= NULL;			// Sender email, leave null to select it automatically		
-	
+
 	// Date and Time settings
 	public $serverTimezone		= 'America/Los_Angeles';	// Server timezone
 	public $usesUserTimezone	= true;				// Whether comment dates should use the user's timezone (JavaScript-mode)

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -34,7 +34,7 @@ class Settings
 	protected $adminPassword	= 'passwd';			// Login password to gain admin rights (case-sensitive)
 
 	// Primary settings
-	public $language		= 'auto';			// UI language, for example 'en', 'de', etc. 'auto' to use system locale
+	public $language		= 'auto';			// UI language, for example 'en', 'de', etc. 'auto' to use system locale, 'manual' to pass required locale to "lang" URL parameter
 	public $theme			= 'default';			// Comment Cascading Style Sheet (CSS)
 	public $usesModeration		= false;			// Whether comments must be approved before they appear to other visitors
 	public $dataFormat		= 'xml';			// Format comments will be stored in; options: xml, json, sql

--- a/hashover/scripts/settings.php
+++ b/hashover/scripts/settings.php
@@ -54,6 +54,13 @@ class Settings
 	public $popularityThreshold	= 5;				// Minimum likes a comment needs to be popular
 	public $popularityLimit		= 2;				// Number of comments allowed to become popular
 
+	// Notification email
+	public $notEmail_subject_txt		= 'New comment';	// The initial part of E-Mail notification subject
+	public $notEmail_subject_appEmail	= false;		// Whether append the sender email to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
+	public $notEmail_subject_appName	= false;		// Whether append the name to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
+	public $notEmail_subject_appPage	= false;		// Whether append the page to the E-Mail notification subject. NOTE, this is useful to prevent grouping done by Webmail softwares like GMail, when more emails arrive with the same subject. So you can never lose a comment.
+	
+	
 	// Date and Time settings
 	public $serverTimezone		= 'America/Los_Angeles';	// Server timezone
 	public $usesUserTimezone	= true;				// Whether comment dates should use the user's timezone (JavaScript-mode)

--- a/hashover/scripts/writecomments.php
+++ b/hashover/scripts/writecomments.php
@@ -189,7 +189,7 @@ class WriteComments extends PostData
 	protected function setHeaders ($email, $user = true)
 	{
 		$this->headers  = 'Content-Type: text/plain; charset=UTF-8' . "\r\n";
-		$this->headers .= 'From: ' . $email . "\r\n";
+		if(NULL!=$this->setup->emailSender) $this->headers .= 'From: ' . $this->setup->emailSender . "\r\n";
 		$this->headers .= 'Reply-To: ' . $email;
 
 		// Set commenter's headers to new value as well
@@ -860,8 +860,7 @@ class WriteComments extends PostData
 				if (!empty ($this->email)) {
 					$from_line .= ' <' . $this->email . '>';
 				}
-				
-				// Custom subject generation
+
 				$webmaster_subject = $this->setup->notEmail_subject_txt;
 				if($this->setup->notEmail_subject_appName)	$webmaster_subject .= ' ' . $writerName;
 				if($this->setup->notEmail_subject_appEmail)	$webmaster_subject .= ' ' . $this->email;

--- a/hashover/scripts/writecomments.php
+++ b/hashover/scripts/writecomments.php
@@ -811,7 +811,8 @@ class WriteComments extends PostData
 
 			// Send notification e-mails
 			$permalink = 'c' . str_replace ('-', 'r', $comment_file);
-			$from_line = !empty ($this->name) ? $this->name : $this->setup->defaultName;
+			$writerName = !empty ($this->name) ? $this->name : $this->setup->defaultName;
+			$from_line = $writerName;
 			$mail_comment = html_entity_decode (strip_tags ($this->commentData['body']), ENT_COMPAT, 'UTF-8');
 			$mail_comment = $this->indentedWordwrap ($mail_comment);
 			$webmaster_reply = '';
@@ -859,6 +860,12 @@ class WriteComments extends PostData
 				if (!empty ($this->email)) {
 					$from_line .= ' <' . $this->email . '>';
 				}
+				
+				// Custom subject generation
+				$webmaster_subject = $this->setup->notEmail_subject_txt;
+				if($this->setup->notEmail_subject_appName)	$webmaster_subject .= ' ' . $writerName;
+				if($this->setup->notEmail_subject_appEmail)	$webmaster_subject .= ' ' . $this->email;
+				if($this->setup->notEmail_subject_appPage)	$webmaster_subject .= ' ' . $this->setup->pageURL;
 
 				$webmaster_message  = 'From ' . $from_line . ":\r\n\r\n";
 				$webmaster_message .= $mail_comment . "\r\n\r\n";
@@ -867,7 +874,7 @@ class WriteComments extends PostData
 				$webmaster_message .= 'Page: ' . $this->setup->pageURL;
 
 				// Send
-				mail ($this->setup->notificationEmail, 'New Comment', $webmaster_message, $this->headers);
+				mail ($this->setup->notificationEmail, $webmaster_subject, $webmaster_message, $this->headers);
 			}
 
 			// Set/update user login cookie

--- a/hashover/scripts/writecomments.php
+++ b/hashover/scripts/writecomments.php
@@ -862,9 +862,9 @@ class WriteComments extends PostData
 				}
 
 				$webmaster_subject = $this->setup->notEmail_subject_txt;
-				if($this->setup->notEmail_subject_appName)	$webmaster_subject .= ' ' . $writerName;
-				if($this->setup->notEmail_subject_appEmail)	$webmaster_subject .= ' ' . $this->email;
-				if($this->setup->notEmail_subject_appPage)	$webmaster_subject .= ' ' . $this->setup->pageURL;
+				if($this->setup->notEmail_subject_appName)	$webmaster_subject .= ' - ' . $writerName;
+				if($this->setup->notEmail_subject_appEmail)	$webmaster_subject .= ' - ' . $this->email;
+				if($this->setup->notEmail_subject_appPage)	$webmaster_subject .= ' - ' . $this->setup->pageURL;
 
 				$webmaster_message  = 'From ' . $from_line . ":\r\n\r\n";
 				$webmaster_message .= $mail_comment . "\r\n\r\n";


### PR DESCRIPTION
I've added an array that contains the list of names where the system'll check to get the language required. These checks is done in $_GET, $_POST, $_COOKIE.

I've made the pull request, becouse I've used this approach to allow HashHover to works with my CMS.