### PR TITLE
 Allow overriding HashOver HTTP root directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/hashover/comments/
+/hashover/config/secrets.ini

--- a/hashover/backend/classes/secrets.php
+++ b/hashover/backend/classes/secrets.php
@@ -23,6 +23,10 @@ class Secrets
 	// Login password to gain admin rights (case-sensitive)
 	protected $adminPassword = 'passwd';
 
+	// HTTP root directory. This is usually auto-detected correctly,
+	// so it does not need to be set in most circumstances.
+	protected $httpRootDirectory = NULL;
+
 	protected function getSecretConfigPath() {
 		return dirname(dirname(__DIR__)) . '/config/secrets.ini';
 	}
@@ -41,5 +45,7 @@ class Secrets
 		$this->encryptionKey = $arr['encryption-key'];
 		$this->adminName = $arr['admin-name'];
 		$this->adminPassword = $arr['admin-password'];
+		if (isset($arr['http-root-directory']))
+			$this->httpRootDirectory = $arr['http-root-directory'];
 	}
 }

--- a/hashover/backend/classes/secrets.php
+++ b/hashover/backend/classes/secrets.php
@@ -7,22 +7,6 @@
 // This applies worldwide. If this is not legally possible, I grant any
 // entity the right to use this work for any purpose, without any
 // conditions, unless such conditions are required by law.
-//
-//--------------------
-//
-// IMPORTANT NOTICE:
-//
-// To retain your settings and maintain proper functionality, when
-// downloading or otherwise upgrading to a new version of HashOver it
-// is important that you preserve this file, unless directed otherwise.
-//
-// It is also important to choose UNIQUE values for the encryption key,
-// admin name, and admin password, as not doing so puts HashOver at
-// risk of being hijacked. Allowing someone to delete comments and/or
-// edit existing comments to post spam, impersonate you or your
-// visitors in order to push some sort of agenda/propaganda, to defame
-// you or your visitors, or to imply endorsement of some product(s),
-// service(s), and/or political ideology.
 
 
 class Secrets
@@ -38,4 +22,24 @@ class Secrets
 
 	// Login password to gain admin rights (case-sensitive)
 	protected $adminPassword = 'passwd';
+
+	protected function getSecretConfigPath() {
+		return dirname(dirname(__DIR__)) . '/config/secrets.ini';
+	}
+
+	function __construct() {
+		$config_file_name = $this->getSecretConfigPath();
+		if (!file_exists($config_file_name)) {
+			throw new \Exception (sprintf (
+				'Please create the file %s (using secrets.ini.sample as a template)',
+				$config_file_name
+			));
+		}
+
+		$arr = parse_ini_file($config_file_name);
+		$this->notificationEmail = $arr['notification-email'];
+		$this->encryptionKey = $arr['encryption-key'];
+		$this->adminName = $arr['admin-name'];
+		$this->adminPassword = $arr['admin-password'];
+	}
 }

--- a/hashover/backend/classes/settings.php
+++ b/hashover/backend/classes/settings.php
@@ -154,15 +154,16 @@ class Settings extends Secrets
 		// Get HTTP parent directory
 		$document_root = realpath ($_SERVER['DOCUMENT_ROOT']);
 
-		if (defined('HASHOVER_HTTP_DIRECTORY')) {
-			$http_directory = HASHOVER_HTTP_DIRECTORY;
+		if ($this->httpRootDirectory !== NULL) {
+			$http_directory = $this->httpRootDirectory;
 		} else {
 			if (mb_substr ($root_directory, 0, mb_strlen ($document_root)) != $document_root) {
 				throw new \Exception (sprintf (
 					'PHP root directory (%s) does not start with the HTTP document root (%s)! ' .
-					'Please define HASHOVER_HTTP_DIRECTORY pointing to the HTTP URL ' .
+					'Please set http-root-directory in %s pointing to the HTTP URL ' .
 					'of the root HashOver directory (e.g. "/hashover").',
-					$root_directory, $document_root
+					$root_directory, $document_root,
+					$this->getSecretConfigPath()
 				));
 			}
 			$http_directory = mb_substr ($root_directory, mb_strlen ($document_root));

--- a/hashover/backend/classes/settings.php
+++ b/hashover/backend/classes/settings.php
@@ -137,6 +137,8 @@ class Settings extends Secrets
 
 	public function __construct ()
 	{
+		parent::__construct();
+
 		// Theme path
 		$this->themePath = 'themes/' . $this->theme;
 

--- a/hashover/backend/classes/settings.php
+++ b/hashover/backend/classes/settings.php
@@ -152,17 +152,23 @@ class Settings extends Secrets
 		// Get HTTP parent directory
 		$document_root = realpath ($_SERVER['DOCUMENT_ROOT']);
 
-		if (mb_substr ($root_directory, 0, mb_strlen ($document_root)) != $document_root) {
-			throw new \Exception (sprintf (
-				'PHP root directory (%s) does not start with the HTTP document root (%s)!',
-				$root_directory, $document_root
-			));
-		}
-		$http_directory = mb_substr ($root_directory, mb_strlen ($document_root));
+		if (defined('HASHOVER_HTTP_DIRECTORY')) {
+			$http_directory = HASHOVER_HTTP_DIRECTORY;
+		} else {
+			if (mb_substr ($root_directory, 0, mb_strlen ($document_root)) != $document_root) {
+				throw new \Exception (sprintf (
+					'PHP root directory (%s) does not start with the HTTP document root (%s)! ' .
+					'Please define HASHOVER_HTTP_DIRECTORY pointing to the HTTP URL ' .
+					'of the root HashOver directory (e.g. "/hashover").',
+					$root_directory, $document_root
+				));
+			}
+			$http_directory = mb_substr ($root_directory, mb_strlen ($document_root));
 
-		// Replace backslashes with forward slashes on Windows
-		if (DIRECTORY_SEPARATOR === '\\') {
-			$http_directory = str_replace ('\\', '/', $http_directory);
+			// Replace backslashes with forward slashes on Windows
+			if (DIRECTORY_SEPARATOR === '\\') {
+				$http_directory = str_replace ('\\', '/', $http_directory);
+			}
 		}
 
 		// Determine HTTP or HTTPS

--- a/hashover/backend/classes/settings.php
+++ b/hashover/backend/classes/settings.php
@@ -151,6 +151,13 @@ class Settings extends Secrets
 
 		// Get HTTP parent directory
 		$document_root = realpath ($_SERVER['DOCUMENT_ROOT']);
+
+		if (mb_substr ($root_directory, 0, mb_strlen ($document_root)) != $document_root) {
+			throw new \Exception (sprintf (
+				'PHP root directory (%s) does not start with the HTTP document root (%s)!',
+				$root_directory, $document_root
+			));
+		}
 		$http_directory = mb_substr ($root_directory, mb_strlen ($document_root));
 
 		// Replace backslashes with forward slashes on Windows

--- a/hashover/backend/classes/setup.php
+++ b/hashover/backend/classes/setup.php
@@ -111,7 +111,7 @@ class Setup extends Settings
 		if ($this->notificationEmail === 'example@example.com') {
 			throw new \Exception (sprintf (
 				'You must use a UNIQUE notification e-mail in %s',
-				$this->getBackendPath ('classes/settings.php')
+				$this->getSecretConfigPath()
 			));
 		}
 
@@ -119,7 +119,7 @@ class Setup extends Settings
 		if ($this->encryptionKey === '8CharKey') {
 			throw new \Exception (sprintf (
 				'You must use a UNIQUE encryption key in %s',
-				$this->getBackendPath ('classes/settings.php')
+				$this->getSecretConfigPath()
 			));
 		}
 
@@ -127,7 +127,7 @@ class Setup extends Settings
 		if ($this->adminPassword === 'password') {
 			throw new \Exception (sprintf (
 				'You must use a UNIQUE admin password in %s',
-				$this->getBackendPath ('classes/settings.php')
+				$this->getSecretConfigPath()
 			));
 		}
 

--- a/hashover/config/secrets.ini.sample
+++ b/hashover/config/secrets.ini.sample
@@ -1,0 +1,25 @@
+; IMPORTANT NOTICE:
+;
+; To retain your settings and maintain proper functionality, when
+; downloading or otherwise upgrading to a new version of HashOver it
+; is important that you preserve this file, unless directed otherwise.
+;
+; It is also important to choose UNIQUE values for the encryption key,
+; admin name, and admin password, as not doing so puts HashOver at
+; risk of being hijacked. Allowing someone to delete comments and/or
+; edit existing comments to post spam, impersonate you or your
+; visitors in order to push some sort of agenda/propaganda, to defame
+; you or your visitors, or to imply endorsement of some product(s),
+; service(s), and/or political ideology.
+
+; E-mail for notification of new comments
+notification-email = example@example.com
+
+; Unique encryption key (case-sensitive)
+encryption-key = 8CharKey
+
+; Login name to gain admin rights (case-sensitive)
+admin-name = admin
+
+; Login password to gain admin rights (case-sensitive)
+admin-password = passwd

--- a/hashover/config/secrets.ini.sample
+++ b/hashover/config/secrets.ini.sample
@@ -23,3 +23,7 @@ admin-name = admin
 
 ; Login password to gain admin rights (case-sensitive)
 admin-password = passwd
+
+; HTTP root directory. This is usually auto-detected correctly,
+; so it does not need to be set in most circumstances.
+; http-root-directory = /hashover


### PR DESCRIPTION
Fixes #211.

Last commit (`secrets.ini` template) depends on the first part of #213.