### PR TITLE
Always load theme CSS in control panel

### DIFF
--- a/hashover/backend/classes/setup.php
+++ b/hashover/backend/classes/setup.php
@@ -149,6 +149,12 @@ class Setup extends Settings
 				$this->imageFormat = 'svg';
 			}
 		}
+
+		// Check if this is a request from the moderation panel
+		if ($this->usage['context'] === 'moderation') {
+			// If so, always load CSS
+			$this->appendsCss = true;
+		}
 	}
 
 	public function extensionsLoaded (array $extensions)

--- a/hashover/comments.php
+++ b/hashover/comments.php
@@ -24,7 +24,7 @@ try {
 	// Instantiate general setup class
 	$setup = new Setup (array (
 		'mode' => 'javascript',
-		'context' => 'normal'
+		'context' => isset ($_GET['nodefault']) ? 'moderation' : 'normal'
 	));
 
 	// Instantiate HashOver statistics class


### PR DESCRIPTION
Fix #218.

Always loading the default theme, as suggested there, is a bit more tricky, as it requires `threads.php` to tell `comments.php` to tell `comment-ajax.php` to use the default theme.