### PR TITLE
Use <code> for inline code, <pre> for code blocks

### DIFF
--- a/hashover/backend/classes/markdown.php
+++ b/hashover/backend/classes/markdown.php
@@ -79,13 +79,13 @@ class Markdown
 	// Returns the original inline markdown code with HTML replacement
 	protected function inlineCodeReturn ($grp)
 	{
-		return '<code class="hashover-inline">' . $this->codeMarkers['inline']['marks'][($grp[1])] . '</code>';
+		return '<code>' . $this->codeMarkers['inline']['marks'][($grp[1])] . '</code>';
 	}
 
 	// Returns the original markdown code block with HTML replacement
 	protected function blockCodeReturn ($grp)
 	{
-		return '<code>' . $this->codeMarkers['block']['marks'][($grp[1])] . '</code>';
+		return '<pre>' . $this->codeMarkers['block']['marks'][($grp[1])] . '</pre>';
 	}
 
 	// Parses a string as markdown

--- a/hashover/frontend/markdown.js
+++ b/hashover/frontend/markdown.js
@@ -80,7 +80,7 @@ HashOverConstructor.prototype.markdown = {
 
 			// Return the original markdown code with HTML replacement
 			paragraphs[i] = paragraphs[i].replace (this.inlineCodeMarker, function (marker, number) {
-				return '<code class="hashover-inline">' + markdown.codeMarkers.inline.marks[number] + '</code>';
+				return '<code>' + markdown.codeMarkers.inline.marks[number] + '</code>';
 			});
 		}
 
@@ -89,7 +89,7 @@ HashOverConstructor.prototype.markdown = {
 
 		// Replace code block markers with original markdown code
 		string = string.replace (this.blockCodeMarker, function (marker, number) {
-			return '<code>' + markdown.codeMarkers.block.marks[number] + '</code>';
+			return '<pre>' + markdown.codeMarkers.block.marks[number] + '</pre>';
 		});
 
 		return string;

--- a/hashover/themes/1.0-ported/comments.css
+++ b/hashover/themes/1.0-ported/comments.css
@@ -677,7 +677,6 @@ Copyright (C) 2014-2018 Jacob Barkdull
 #hashover .hashover-comment code {
 	width: 100%;
 	max-height: 200px;
-	display: inline-block;
 	overflow: auto;
 	border: 1px solid #C1C1C1;
 	background-color: #F5F5F5;
@@ -686,8 +685,7 @@ Copyright (C) 2014-2018 Jacob Barkdull
 	margin: 0px;
 }
 
-#hashover code.hashover-inline {
-	display: inline;
+#hashover code {
 	padding: 1px 4px;
 	border-radius: 0px;
 	font-size: 12px;

--- a/hashover/themes/default-borderless/comments.css
+++ b/hashover/themes/default-borderless/comments.css
@@ -913,7 +913,6 @@ Copyright (C) 2016-2018 Jacob Barkdull
 
 .hashover .hashover-comment pre,
 .hashover .hashover-comment code {
-	display: inline-block;
 	width: 100%;
 	max-height: 400px;
 	white-space: pre;
@@ -925,8 +924,7 @@ Copyright (C) 2016-2018 Jacob Barkdull
 	overflow: auto;
 }
 
-.hashover code.hashover-inline {
-	display: inline;
+.hashover code {
 	padding: 1px 4px;
 }
 

--- a/hashover/themes/default/comments.css
+++ b/hashover/themes/default/comments.css
@@ -873,7 +873,6 @@ Copyright (C) 2016-2018 Jacob Barkdull
 
 .hashover .hashover-comment pre,
 .hashover .hashover-comment code {
-	display: inline-block;
 	width: 100%;
 	max-height: 400px;
 	white-space: pre;
@@ -885,8 +884,7 @@ Copyright (C) 2016-2018 Jacob Barkdull
 	overflow: auto;
 }
 
-.hashover code.hashover-inline {
-	display: inline;
+.hashover code {
 	padding: 1px 4px;
 }
 


### PR DESCRIPTION
Stop breaking convention with semantic HTML and pretty much all
Markdown implementations.

This change simplifies CSS and puts HashOver in line with most other
comment systems using Markdown, which has the benefit of making
migrations to or from HashOver easier.