### PR TITLE
Add utf8mb4 charset hint to database documentation

### DIFF
--- a/admin/docs/en-us/setup/setup.html
+++ b/admin/docs/en-us/setup/setup.html
@@ -137,7 +137,8 @@
 			<code>$databaseCharset</code>
 		</dt>
 		<dd>
-			The character set of the comments being stored in the database.
+			The character set of the comments being stored in the database. Set to
+			<code>utf8mb4</code> when using MySQL or MariaDB (to support emojis).
 		</dd>
 	</dl>
 


### PR DESCRIPTION
utf8 is an alias for utf8mb3 in MySQL and MariaDB.
Some emojis use 4-bytes, so recommend utf8mb4.