### PR TITLE
Enable HTTP caching (performance)

### DIFF
--- a/api/backend/count-link-ajax.php
+++ b/api/backend/count-link-ajax.php
@@ -29,6 +29,12 @@ if (isset ($_GET['jsonp'])) {
 	require ('backend/json-setup.php');
 }
 
+// Frequently changing resource, but clients are fine with one-minute freshness.
+// Intermediary servers get 2–60 second freshness depending on demand.
+// Override it on your webserver.
+header('Cache-Control: max-age=2, stale-while-revalidate=58, stale-if-error=300', true);
+header('Pragma: ', true;
+
 try {
 	// Instantiate HashOver class
 	$hashover = new \HashOver ('json');

--- a/api/backend/latest-ajax.php
+++ b/api/backend/latest-ajax.php
@@ -29,6 +29,13 @@ if (isset ($_GET['jsonp'])) {
 	require ('backend/json-setup.php');
 }
 
+
+// Frequently changing resource, but clients are fine with one-minute freshness.
+// Intermediary servers get 2–60 second freshness depending on demand.
+// Override it on your webserver.
+header('Cache-Control: max-age=2, stale-while-revalidate=58, stale-if-error=300', true);
+header('Pragma: ', true);
+
 try {
 	// Instantiate HashOver class
 	$hashover = new \HashOver ('json');

--- a/api/count-link.php
+++ b/api/count-link.php
@@ -23,6 +23,11 @@ chdir (realpath ('../'));
 // Setup HashOver for JavaScript
 require ('backend/javascript-setup.php');
 
+// Mostly static asset (unless settings are changed); suitable for client-
+// side caching. 30 min and 1 day - 30 min. Override it on your webserver.
+header('Cache-Control: max-age=1800, stale-while-revalidate=84600', true);
+header('Pragma: ', true);
+
 try {
 	// Instantiate general setup class
 	$setup = new Setup ('javascript');

--- a/api/latest.php
+++ b/api/latest.php
@@ -23,6 +23,11 @@ chdir (realpath ('../'));
 // Setup HashOver for JavaScript
 require ('backend/javascript-setup.php');
 
+// Mostly static asset (unless settings are changed); suitable for client-
+// side caching. 30 min and 1 day - 30 min. Override it on your webserver.
+header('Cache-Control: max-age=1800, stale-while-revalidate=84600', true);
+header('Pragma: ', true);
+
 try {
 	// Instantiate general setup class
 	$setup = new Setup ('javascript');

--- a/backend/classes/cookies.php
+++ b/backend/classes/cookies.php
@@ -117,6 +117,8 @@ class Cookies
 		// Add pseudo-namespacing prefix to cookie name
 		$name = 'hashover-' . $name;
 
+		header('Vary: Cookie', false);
+
 		// Check if cookie exists
 		if (!empty ($_COOKIE[$name])) {
 			// If so, store as value for cleaner code

--- a/backend/classes/setup.php
+++ b/backend/classes/setup.php
@@ -92,10 +92,17 @@ class Setup extends Settings
 			$this->website = 'all';
 		}
 
-		header('Vary: User-Agent', false);
+		header('Vary: User-Agent, Sec-CH-UA-Mobile', false);
+
+ 		// Check if we have a mobile client hint header
+		if (!empty( $_SERVER['HTTP_SEC_CH_UA_MOBILE'])) {
+			if ($_SERVER['HTTP_SEC_CH_UA_MOBILE'] == '?1') {
+				$this->isMobile = true;
+			}
+		}
 
 		// Check if we have a user agent
-		if (!empty ($_SERVER['HTTP_USER_AGENT'])) {
+		else if (!empty ($_SERVER['HTTP_USER_AGENT'])) {
 			// If so, get user agent
 			$agent = $_SERVER['HTTP_USER_AGENT'];
 

--- a/backend/classes/setup.php
+++ b/backend/classes/setup.php
@@ -92,6 +92,8 @@ class Setup extends Settings
 			$this->website = 'all';
 		}
 
+		header('Vary: User-Agent', false);
+
 		// Check if we have a user agent
 		if (!empty ($_SERVER['HTTP_USER_AGENT'])) {
 			// If so, get user agent
@@ -238,6 +240,8 @@ class Setup extends Settings
 	// Checks remote request against allowed domains setting
 	public function refererCheck ()
 	{
+		header('Vary: Referer', false);
+
 		// Return true if no referer is set
 		if (empty ($_SERVER['HTTP_REFERER'])) {
 			return true;

--- a/backend/nocache-headers.php
+++ b/backend/nocache-headers.php
@@ -18,8 +18,5 @@
 
 
 // Disable browser cache
-header ('Expires: Wed, 08 May 1991 12:00:00 GMT');
-header ('Last-Modified: ' . gmdate ('D, d M Y H:i:s') . ' GMT');
-header ('Cache-Control: no-store, no-cache, must-revalidate');
-header ('Cache-Control: post-check=0, pre-check=0', false);
+header ('Cache-Control: no-cache, max-age=0');
 header ('Pragma: no-cache');

--- a/comments.php
+++ b/comments.php
@@ -20,6 +20,11 @@
 // Setup HashOver for JavaScript
 require ('backend/javascript-setup.php');
 
+// Mostly static asset (unless settings are changed); suitable for client-
+// side caching. 30 min and 1 day - 30 min. Override it on your webserver.
+header('Cache-Control: max-age=1800, stale-while-revalidate=84600', true);
+header('Pragma: ', true);
+
 try {
 	// Instantiate general setup class
 	$setup = new Setup ('javascript');


### PR DESCRIPTION
* Send HTTP Vary hints to caches when varying on HTTP request headers.
* Enable caching for static script assets for the Comment, Count, and Latest APIs. These are mostly static, except when the admin changes server setting. Clients cache for 30 min and use stale while async revalidation for 1 day.
* The Count and Latest APIs also get short-lived cache headers. These don’t work just yet as the APIs use `POST` requests to get stuff. Fixing that is a slightly larger task, and I’ll address that (along with `private` cache headers for the Comment API.)
* Removed some ancient cache control headers and focus on the ones that work. (HTTP/1.0+ compatible.)

This only enabled caching on some assets, and not any responses that change per-user or based on cookies. It means admins may be confused by their sites not immediately changing when they change a setting that modifies these assets. I decided to focus on the end user and their experience instead. You should’t need to change settings all that often, so this is a much smaller use case anyway. A compromise could be to disable caching for the admins, but this wouldn’t be a true representation of how users experience their sites. (Admins using HashOver are therefor expected to understand caching and how to turn it off in developer tools.) 

I thought long and hard about where to put the caching headers. I decided they belonged where they’re used. I figured confused developers would look at the code to figure out why a changed setting didn’t apply as expected. Greeting them with the cache header should explain it, so it’s better for code readability. I can make it a function inside `Setup` instead if you hate this.

Bonus sneaking in along with the others:

* Use the modern `Sec-CH-UA-Mobile` client hint instead of `User-Agent` to determine device mobileness (when available; e.g. Edge and Chrome over HTTPS). This is part of the client hints standard and is meant to replace User-Agents in the future. Among other things, it’s better for caching (varying on one boolean vs the entire User-Agent string).

Each change is its own commit, so you can merge just the parts you want.