### PR TITLE
Mention the `data-format` setting in SQL Setup

### DIFF
--- a/admin/docs/en-us/setup/setup.html
+++ b/admin/docs/en-us/setup/setup.html
@@ -71,6 +71,12 @@
 	</h2>
 
 	<p>
+		By default, HashOver stores comments in XML files. Where comments are stored
+		is configured using the <a href="../settings/#data-format"><code>data-format</code>
+		setting</a>. You must set this to <code>sql</code> for the below options to take effect.
+	</p>
+
+	<p>
 		The following settings are optional, but required if you plan to store
 		comments in a MySQL database or any other SQL server supported by
 		<a href="https://www.php.net/manual/en/pdo.drivers.php" target="_blank">PDO</a>


### PR DESCRIPTION
The `databaseType` and `data-format` settings need to be changed together. It’s a likely source of confusion.