### PR TITLE
Fix comment thread name in moderation

### DIFF
--- a/backend/comment-info.php
+++ b/backend/comment-info.php
@@ -32,6 +32,9 @@ function get_json_response ($hashover)
 	// Initial JSON data
 	$data = array ();
 
+	// Set threadName from GET data
+	$hashover->setup->setThreadName ();
+
 	// Get comment from POST/GET data
 	$key = $hashover->setup->getRequest ('comment', null);
 


### PR DESCRIPTION
The moderation page gets the correct `threadName`, and passes it along as a GET to `threads.php`. However, editing failed to read the comments because it used the default `threadName` instead of the custom one. Not sure why `comment-info` uses the wrong `threadName` here, though.