### PR TITLE
Make it easier to notice pending comments

### DIFF
--- a/backend/classes/commentsui.php
+++ b/backend/classes/commentsui.php
@@ -20,11 +20,13 @@
 class CommentsUI extends FormUI
 {
 	// Creates a wrapper element for each comment
-	public function commentWrapper ($permalink = '{permalink}')
+	public function commentWrapper ($permalink = '{permalink}', $status = '{status}')
 	{
+		$status_class = (! empty($status)) ? " hashover-status-${status}" : '';
+
 		$comment_wrapper = new HTMLTag ('div', array (
 			'id' => $this->prefix ($permalink),
-			'class' => 'hashover-comment'
+			'class' => 'hashover-comment' . $status_class
 		), false);
 
 		if ($this->mode !== 'php') {

--- a/backend/classes/phpmode.php
+++ b/backend/classes/phpmode.php
@@ -215,8 +215,11 @@ class PHPMode
 		$permatext = explode ('r', $permatext);
 		$permatext = array_pop ($permatext);
 
+		// Post moderation status
+		$status = isset ($comment['status']) ? $comment['status'] : null;
+
 		// Wrapper element for each comment
-		$comment_wrapper = $this->ui->commentWrapper ($permalink);
+		$comment_wrapper = $this->ui->commentWrapper ($permalink, $comment['status']);
 
 		// Check if this comment is a popular comment
 		if ($popular === true) {

--- a/frontend/parsecomment.js
+++ b/frontend/parsecomment.js
@@ -429,6 +429,11 @@ HashOverConstructor.prototype.parseComment = function (comment, parent, collapse
 		}
 	}
 
+	// Append status class
+	if (comment['status']) {
+		classes += ` hashover-status-${comment['status']}`;
+	}
+
 	// Wrap comment HTML
 	var wrapper = this.strings.parseTemplate (
 		this.ui['comment-wrapper'], {

--- a/themes/default/comments.css
+++ b/themes/default/comments.css
@@ -649,6 +649,15 @@ conditions, unless such conditions are required by law.
 	/*background-color: #FFE5F0;*/
 }
 
+.hashover .hashover-comment.hashover-status-pending > .hashover-header {
+	/* Light red (pink-ish) */
+	background-color: #FFE5F0;
+
+	/* Sriped light red (pink-ish) and light blue */
+	background-image: linear-gradient(45deg, #FFE5F0 25%, #E5F0FF 25%, #E5F0FF 50%, #FFE5F0 50%, #FFE5F0 75%, #E5F0FF 75%, #     E5F0FF 100%);
+	background-size: 50px 50px;
+}
+
 .hashover .hashover-avatar-image *,
 .hashover .hashover-avatar *,
 .hashover .hashover-reply .hashover-header,


### PR DESCRIPTION
It’s hard to find comments pending moderation in the moderation view, and they’re easy to miss when looking at a discussion.

* Added `hashover-status-{status}` classes to the `hashover-comment` wrapper (except for approved comments).
* Changed the `.hashover-header` background for comments pending moderation (only admins see these). I piked a striped blue/red background, separate commit in case you want a different style.
