### PR TITLE
Enable content-visibility optimization

### DIFF
--- a/themes/default/comments.css
+++ b/themes/default/comments.css
@@ -269,6 +269,12 @@ conditions, unless such conditions are required by law.
 	padding: 0px 3px 0px 3px;
 }
 
+.hashover .hashover-comment {
+	contain: content;
+	contain-intrinsic-size: 0 170px;
+	content-visibility: auto;
+}
+
 .hashover .hashover-comment,
 .hashover .hashover-reply-form,
 .hashover .hashover-comment .hashover-avatar,


### PR DESCRIPTION
Browsers will assume comments are 170px tall (about three lines including headers). They can then cheat by not rendering all off-screen comments before they’re needed. Improves page-load performance in large discussion. ([Explainer](https://www.youtube.com/watch?v=FFA-v-CIxJQ).)